### PR TITLE
Fix page title content

### DIFF
--- a/views/questions/technical/class-vs-object.html
+++ b/views/questions/technical/class-vs-object.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8">
-    <title>Fizz Buzz | Software Interview Technical Questions </title>
+    <title>Class vs Object | Software Interview Technical Questions </title>
     <meta name="description" content="Creators of Approachable Open Source projects to allow anyone to start contribute to open source software, regardless of technical skill level.">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../../styles.css">


### PR DESCRIPTION
The "Class vs Object" page had the title "Fizz Buzz", which refers
to another page.

### Please check if this PR fulfills these
- [x] The commit message is descriptive of changes
- [x] You have tried at least one local test (this includes viewing the changes on your local fork)
- [x] Docs have been added / updated as needed (for bug fixes / features) 

### What kind of change does this PR introduce? 

- [x] Typo / Doc Update
- [ ] Bug Fix <!-- Including Fixes Issue #  will close an issue when merged -->
- [ ] Feature / New Item

### What is the new behavior (if this is a feature change)?

- [ ] Added Interview Technical Question
- [ ] Added Interview Whiteboard Question
- [x] Corrected existing items
- [ ] Other

### Other information:
